### PR TITLE
Fix source object

### DIFF
--- a/src/BidRequest/Source.php
+++ b/src/BidRequest/Source.php
@@ -64,7 +64,7 @@ class Source implements Arrayable
      */
     public function setFd($fd)
     {
-        $this->validateIn($allimps, BitType::getAll());
+        $this->validateIn($fd, BitType::getAll());
         $this->fd = $fd;
 
         return $this;

--- a/src/BidRequest/Source.php
+++ b/src/BidRequest/Source.php
@@ -45,6 +45,11 @@ class Source implements Arrayable
     protected $pchain;
 
     /**
+     * @var Ext
+     */
+    protected $ext;
+
+    /**
      * @return bool
      */
     public function getFd()
@@ -107,6 +112,21 @@ class Source implements Arrayable
         return $this;
     }
 
+    /**
+     * @return Ext
+     */
+    public function getExt()
+    {
+        return $this->ext;
+    }
 
-
+    /**
+     * @param Ext $ext
+     * @return $this
+     */
+    public function setExt(Ext $ext)
+    {
+        $this->ext = $ext;
+        return $this;
+    }
 }


### PR DESCRIPTION
In [OpenRTB Specification 2.5](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf), the object `Source` can have an `ext` attribute.

Also in the object `Source`, the validator in `setFd` use the var `$allimps` instead of `$fd`
